### PR TITLE
Payments

### DIFF
--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -134,7 +134,6 @@ def tip():
     return Seq([
         Assert(
             And(
-                Txn.sender() == App.globalGet(tipper), #maybe remove this
                 Gtxn[on_stake_tx_index].sender() == Txn.sender(),
                 Gtxn[on_stake_tx_index].receiver() == Global.current_application_address(),
                 Gtxn[on_stake_tx_index].type_enum() == TxnType.Payment,

--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -15,6 +15,7 @@ reporter = Bytes("reporter_address")
 currently_staked = Bytes("currently_staked")
 timestamp = Bytes("timestamp")
 value = Bytes("value")
+tip_amount = Bytes("tip_amount")
 
 """
 functions listed in alphabetical order
@@ -42,6 +43,7 @@ def create():
     return Seq(
         [
             App.globalPut(tipper, Txn.sender()),
+            App.globalPut(tip_amount, Int(0)),
             # TODO assert application args length is correct
             App.globalPut(governance_address, Txn.application_args[0]),
             App.globalPut(query_id, Txn.application_args[1]),
@@ -80,6 +82,28 @@ def report():
             Approve(),
         ]
     )
+
+def tip():
+    """
+    provide a reward to the reporter for reporting
+
+    Txn args:
+    0) will always equal "tip" (in order to route to this method) 
+    """
+    on_stake_tx_index = Txn.group_index() - Int(1)
+
+    return Seq([
+        Assert(
+            And(
+                Txn.sender() == App.globalGet(tipper),
+                Gtxn[on_stake_tx_index].sender() == Txn.sender(),
+                Gtxn[on_stake_tx_index].receiver() == Global.current_application_address(),
+                Gtxn[on_stake_tx_index].type_enum() == TxnType.Payment,
+            ),
+        ),
+
+        App.globalPut(tip_amount, App.globalGet(tip_amount) + Gtxn[on_stake_tx_index].amount())
+    ])
 
 
 def withdraw():

--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -79,6 +79,45 @@ def report():
             ),
             App.globalPut(value, Txn.application_args[2]),
             App.globalPut(timestamp, Int(int(time.time()))),
+
+            InnerTxnBuilder.Begin(),
+            InnerTxnBuilder.SetFields({
+                TxnField.type_enum: TxnType.Payment,
+                TxnField.amount: App.globalGet(tip_amount),
+                TxnField.receiver: Txn.sender()
+            }),
+            InnerTxnBuilder.Submit(),
+
+            Approve(),
+        ]
+    )
+
+def stake():
+    """
+    gives permission to reporter to report values
+    changes permission when the contract
+    receives the reporter's stake
+
+    Args:
+    0) will always be equal to "stake"
+    """
+
+    on_stake_tx_index = Txn.group_index() - Int(1)
+
+    # enforced two part Gtxn: 1) send token to contract, 2) stake
+    return Seq(
+        [
+            Assert(
+                And(
+                    App.globalGet(reporter) == Bytes(""),
+                    Gtxn[on_stake_tx_index].sender() == Txn.sender(),
+                    Gtxn[on_stake_tx_index].receiver() == Global.current_application_address(),
+                    Gtxn[on_stake_tx_index].amount() == App.globalGet(stake_amount),
+                    Gtxn[on_stake_tx_index].type_enum() == TxnType.Payment,
+                ),
+            ),
+            App.globalPut(staking_status, Int(1)),
+            App.globalPut(reporter, Gtxn[on_stake_tx_index].sender()),
             Approve(),
         ]
     )
@@ -95,7 +134,7 @@ def tip():
     return Seq([
         Assert(
             And(
-                Txn.sender() == App.globalGet(tipper),
+                Txn.sender() == App.globalGet(tipper), #maybe remove this
                 Gtxn[on_stake_tx_index].sender() == Txn.sender(),
                 Gtxn[on_stake_tx_index].receiver() == Global.current_application_address(),
                 Gtxn[on_stake_tx_index].type_enum() == TxnType.Payment,
@@ -191,38 +230,6 @@ def vote():
             Approve(),
         ]
     )
-
-
-def stake():
-    """
-    gives permission to reporter to report values
-    changes permission when the contract
-    receives the reporter's stake
-
-    Args:
-    0) will always be equal to "stake"
-    """
-
-    on_stake_tx_index = Txn.group_index() - Int(1)
-
-    # enforced two part Gtxn: 1) send token to contract, 2) stake
-    return Seq(
-        [
-            Assert(
-                And(
-                    App.globalGet(reporter) == Bytes(""),
-                    Gtxn[on_stake_tx_index].sender() == Txn.sender(),
-                    Gtxn[on_stake_tx_index].receiver() == Global.current_application_address(),
-                    Gtxn[on_stake_tx_index].amount() == App.globalGet(stake_amount),
-                    Gtxn[on_stake_tx_index].type_enum() == TxnType.Payment,
-                ),
-            ),
-            App.globalPut(staking_status, Int(1)),
-            App.globalPut(reporter, Gtxn[on_stake_tx_index].sender()),
-            Approve(),
-        ]
-    )
-
 
 def handle_method():
     """


### PR DESCRIPTION
Supports:
- anyone with ALGO can tip the `query_id`
- reporters claim new tips on each submitted value