### PR TITLE
tested freshness (brenda's bug)

### DIFF
--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -39,7 +39,6 @@ def create():
     """
     return Seq(
         [
-            Assert(timestamp_freshness > Int(120)),
             App.globalPut(governance_address, Txn.sender()),  # governance multisig
             App.globalPut(tip_amount, Int(0)),
             App.globalPut(query_id, Txn.application_args[0]),  # query id to report
@@ -50,6 +49,7 @@ def create():
             App.globalPut(timestamp_freshness, Btoi(Txn.application_args[3])),  # to check age of timestamp against
             App.globalPut(lock_timestamp, Int(0)),
             App.globalPut(stake_amount, Int(200000)),  # 200 ALGOs stake amount
+            Assert(App.globalGet(timestamp_freshness) > Int(120)),
             Approve(),
         ]
     )

--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -39,6 +39,7 @@ def create():
     """
     return Seq(
         [
+            Assert(Btoi(Txn.application_args[3]) >= Int(120)),
             App.globalPut(governance_address, Txn.sender()),  # governance multisig
             App.globalPut(tip_amount, Int(0)),
             App.globalPut(query_id, Txn.application_args[0]),  # query id to report
@@ -49,7 +50,6 @@ def create():
             App.globalPut(timestamp_freshness, Btoi(Txn.application_args[3])),  # to check age of timestamp against
             App.globalPut(lock_timestamp, Int(0)),
             App.globalPut(stake_amount, Int(200000)),  # 200 ALGOs stake amount
-            Assert(App.globalGet(timestamp_freshness) > Int(120)),
             Approve(),
         ]
     )

--- a/src/scripts/deploy.py
+++ b/src/scripts/deploy.py
@@ -1,12 +1,10 @@
 """
 deployment script for testnet or devnet
 """
-from multiprocessing.sharedctypes import Value
 import os
 import sys
 
 from algosdk.error import AlgodHTTPError
-
 from algosdk.future.transaction import Multisig
 from algosdk.v2client.algod import AlgodClient
 from dotenv import load_dotenv
@@ -73,12 +71,15 @@ def deploy(query_id: str, query_data: str, timestamp_freshness: int, network: st
 
     try:
         tellor_flex_app_id = s.deploy_tellor_flex(
-            query_id=query_id, query_data=query_data, multisigaccounts_sk=multisig_accounts_sk, timestamp_freshness=timestamp_freshness
+            query_id=query_id,
+            query_data=query_data,
+            multisigaccounts_sk=multisig_accounts_sk,
+            timestamp_freshness=timestamp_freshness,
         )
     except AlgodHTTPError as e:
         if "pc=763" in str(e):
             raise ValueError("timestamp freshness (-tf) must be >= 120")
-        
+
     medianizer_app_id = s.deploy_medianizer(
         timestamp_freshness=timestamp_freshness, multisigaccounts_sk=multisig_accounts_sk, query_id=query_id
     )

--- a/src/scripts/deploy.py
+++ b/src/scripts/deploy.py
@@ -1,8 +1,11 @@
 """
 deployment script for testnet or devnet
 """
+from multiprocessing.sharedctypes import Value
 import os
 import sys
+
+from algosdk.error import AlgodHTTPError
 
 from algosdk.future.transaction import Multisig
 from algosdk.v2client.algod import AlgodClient
@@ -38,14 +41,17 @@ def deploy(query_id: str, query_data: str, timestamp_freshness: int, network: st
         multisig_accounts_pk = [member_1.addr, member_2.addr]
         multisig_accounts_sk = [member_1.getPrivateKey(), member_2.getPrivateKey()]
         governance = Multisig(version=1, threshold=2, addresses=multisig_accounts_pk)
-        print("Multisig Address: ", governance.address())
-        print(
-            "Go to the below link to fund the created account using testnet faucet: \
-            \n https://dispenser.testnet.aws.algodev.network/?account={}".format(
-                governance.address()
+
+        if network == "testnet":
+            print("Multisig Address: ", governance.address())
+            print(
+                "Go to the below link to fund the created account using testnet faucet: \
+                \n https://dispenser.testnet.aws.algodev.network/?account={}".format(
+                    governance.address()
+                )
             )
-        )
-        input("Press Enter to continue...")
+            input("Press Enter to continue...")
+
     elif network == "devnet":
         tipper = getTemporaryAccount(client)
         reporter = getTemporaryAccount(client)
@@ -57,16 +63,22 @@ def deploy(query_id: str, query_data: str, timestamp_freshness: int, network: st
         governance = Multisig(version=1, threshold=2, addresses=multisig_accounts_pk)
         fundAccount(client, governance.address())
         fundAccount(client, reporter.addr)
-        fundAccount(client, reporter.addr)
-        fundAccount(client, reporter.addr)
+        fundAccount(client, tipper.addr)
+        fundAccount(client, member_1.addr)
+        fundAccount(client, member_2.addr)
     else:
         raise Exception("invalid network selected")
 
     s = Scripts(client=client, tipper=tipper, reporter=reporter, governance_address=governance, contract_count=5)
 
-    tellor_flex_app_id = s.deploy_tellor_flex(
-        query_id=query_id, query_data=query_data, multisigaccounts_sk=multisig_accounts_sk, timestamp_freshness=120
-    )
+    try:
+        tellor_flex_app_id = s.deploy_tellor_flex(
+            query_id=query_id, query_data=query_data, multisigaccounts_sk=multisig_accounts_sk, timestamp_freshness=timestamp_freshness
+        )
+    except AlgodHTTPError as e:
+        if "pc=763" in str(e):
+            raise ValueError("timestamp freshness (-tf) must be >= 120")
+        
     medianizer_app_id = s.deploy_medianizer(
         timestamp_freshness=timestamp_freshness, multisigaccounts_sk=multisig_accounts_sk, query_id=query_id
     )

--- a/src/scripts/scripts.py
+++ b/src/scripts/scripts.py
@@ -344,7 +344,8 @@ class Scripts:
 
         submitValueTxn = transaction.ApplicationNoOpTxn(
             sender=self.reporter.getAddress(),
-            accounts=["P5UYSDZJWCOXG6T37XPDMDHGSCJXCNA3X7HBKYSKD5K6TWRPR5Y62PJG5Y"],
+            # accounts=["P5UYSDZJWCOXG6T37XPDMDHGSCJXCNA3X7HBKYSKD5K6TWRPR5Y62PJG5Y"],
+            accounts=[self.governance_address.address()],
             index=self.feed_app_id,
             app_args=[b"report", query_id, value, timestamp],
             foreign_apps=self.feeds + [self.medianizer_app_id],

--- a/src/utils/configs.py
+++ b/src/utils/configs.py
@@ -41,7 +41,7 @@ def get_configs(args: List[str]) -> Box:
 
     parser.add_argument(
         "-tf",
-        "--timestamp_freshness",
+        "--timestamp-freshness",
         nargs=1,
         required=False,
         type=int,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def scripts(client, accounts):
 
 
 @pytest.fixture(autouse=True)
-def deployed_contract(accounts, client, scripts):
+def deployed_contract(accounts, client, scripts: Scripts):
     """deploys feeds and medianizer contracts, provides app ids for all contracts"""
 
     fundAccount(client, accounts.governance.address())


### PR DESCRIPTION
feed contracts revert stale values, preventing a case where report() sends a stale value to the median, triggering the medianizer to find a new median, causing the medianizer to return `None` as the new median because none of the feed's values are up to date